### PR TITLE
Refine spreadsheet styling

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,103 +1,10 @@
-import Image from "next/image";
+import Spreadsheet from "@/components/Spreadsheet";
 
 export default function Home() {
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
+    <main className="h-screen p-2 bg-gray-50">
+      <Spreadsheet />
+    </main>
   );
 }
+

--- a/components/Spreadsheet.tsx
+++ b/components/Spreadsheet.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useState } from 'react';
+
+interface Column {
+  id: string;
+  label: string;
+}
+
+interface Row {
+  [key: string]: string;
+}
+
+const allColumns: Column[] = [
+  { id: 'item', label: 'Item' },
+  { id: 'name', label: 'Name' },
+  { id: 'process', label: 'Process' },
+  { id: 'quantity', label: 'Quantity' },
+  { id: 'price', label: 'Price' },
+];
+
+const views = {
+  full: { name: 'Full', columns: ['item', 'name', 'process', 'quantity', 'price'] },
+  summary: { name: 'Summary', columns: ['item', 'quantity', 'price'] },
+};
+
+export default function Spreadsheet() {
+  const emptyRow: Row = {
+    item: '',
+    name: '',
+    process: '',
+    quantity: '',
+    price: '',
+  };
+
+  const [rows, setRows] = useState<Row[]>(Array.from({ length: 20 }, () => ({ ...emptyRow })));
+  const [view, setView] = useState<keyof typeof views>('full');
+
+  const visibleColumns = allColumns.filter((c) => views[view].columns.includes(c.id));
+
+  const handleCellChange = (rowIndex: number, columnId: string, value: string) => {
+    setRows((prev) =>
+      prev.map((row, i) => (i === rowIndex ? { ...row, [columnId]: value } : row))
+    );
+  };
+
+  const addRow = () => {
+    setRows((prev) => [...prev, { ...emptyRow }]);
+  };
+
+  return (
+    <div className="flex flex-col w-full max-w-5xl mx-auto">
+      <div className="flex items-center justify-between mb-2 text-sm">
+        <div className="flex items-center gap-2">
+          <label htmlFor="view-select" className="text-gray-600">
+            View
+          </label>
+          <select
+            id="view-select"
+            value={view}
+            onChange={(e) => setView(e.target.value as keyof typeof views)}
+            className="border border-gray-300 rounded px-1 py-0.5 bg-white dark:bg-neutral-900"
+          >
+            {Object.entries(views).map(([key, v]) => (
+              <option key={key} value={key}>
+                {v.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <button
+          onClick={addRow}
+          className="px-2 py-1 rounded bg-blue-600 text-white hover:bg-blue-700"
+        >
+          + Row
+        </button>
+      </div>
+      <div className="overflow-auto border border-gray-300 rounded">
+        <table className="min-w-full border-collapse text-sm">
+          <thead>
+            <tr>
+              <th className="sticky left-0 z-10 bg-gray-100 dark:bg-neutral-800 border-r border-gray-300 w-8"></th>
+              {visibleColumns.map((col) => (
+                <th
+                  key={col.id}
+                  className="bg-gray-100 dark:bg-neutral-800 border-b border-r border-gray-300 px-2 py-1 text-left font-medium"
+                >
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, rowIndex) => (
+              <tr key={rowIndex} className="even:bg-gray-50 dark:even:bg-neutral-900">
+                <th className="sticky left-0 z-10 bg-gray-100 dark:bg-neutral-800 border-r border-b border-gray-300 text-center font-normal">
+                  {rowIndex + 1}
+                </th>
+                {visibleColumns.map((col) => (
+                  <td key={col.id} className="border-r border-b border-gray-300">
+                    <input
+                      className="w-full px-2 py-1 focus:outline-none"
+                      value={row[col.id] || ''}
+                      onChange={(e) => handleCellChange(rowIndex, col.id, e.target.value)}
+                    />
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- polish sheet UI with row numbers, sticky headers and clearer borders
- lighten home page background for a cleaner presentation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a541dda478832da5481ae2e1ac863a